### PR TITLE
Add extra parameters support for OpenAI compatible providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-inscribe",
-	"version": "1.1.5",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-inscribe",
-			"version": "1.1.5",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@google/genai": "^1.41.0",

--- a/src/providers/openai-compat/provider.ts
+++ b/src/providers/openai-compat/provider.ts
@@ -32,6 +32,7 @@ export class OpenAICompatibleProvider implements Provider {
             ],
             temperature: options.temperature,
             stream: true,
+            ...options.extraParams,
         }, { signal: this.abortcontroller.signal });
 
         let completion = "";

--- a/src/providers/openai-compat/provider.ts
+++ b/src/providers/openai-compat/provider.ts
@@ -32,7 +32,7 @@ export class OpenAICompatibleProvider implements Provider {
             ],
             temperature: options.temperature,
             stream: true,
-            ...options.extraParams,
+            ...this.settings.extraParams,
         }, { signal: this.abortcontroller.signal });
 
         let completion = "";

--- a/src/providers/openai-compat/settings.ts
+++ b/src/providers/openai-compat/settings.ts
@@ -9,4 +9,5 @@ export interface OpenAICompatibleSettings {
     models: string[];
     configured: boolean;
     temperature_range: { min: number; max: number };
+    extraParams: Record<string, unknown>;
 }

--- a/src/settings/provider.ts
+++ b/src/settings/provider.ts
@@ -118,6 +118,29 @@ export class ProviderSettingsModal extends Modal {
 
         this.renderModelSettings(this.plugin.settings.providers.openai_compatible);
         this.renderConnectionStatus(this.plugin.settings.providers.openai_compatible);
+
+        new Setting(contentEl)
+            .setName("Extra parameters")
+            .setDesc("Additional parameters passed to the API (JSON format). Example: {\"chat_template_kwargs\": {\"enable_thinking\": false}}")
+            .addTextArea((text) => {
+                text.inputEl.rows = 5;
+                text
+                    .setValue(JSON.stringify(this.plugin.settings.providers.openai_compatible.extraParams, null, 2))
+                    .setPlaceholder("{}")
+                    .onChange(async (value) => {
+                        try {
+                            const params = value.trim() ? JSON.parse(value) : {};
+                            if (typeof params === 'object' && params !== null && !Array.isArray(params)) {
+                                this.plugin.settings.providers.openai_compatible.extraParams = params;
+                                await this.plugin.saveSettings();
+                            } else {
+                                new Notice("Extra parameters must be a valid JSON object");
+                            }
+                        } catch (e) {
+                            new Notice("Invalid JSON format");
+                        }
+                    });
+            });
     }
 
     async renderGeminiSettings() {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -12,6 +12,7 @@ export interface ProfileOptions {
     userPrompt: string,
     systemPrompt: string,
     temperature: number,
+    extraParams: Record<string, unknown>,
 }
 
 // Profile settings
@@ -142,6 +143,7 @@ export const DEFAULT_SETTINGS: Settings = {
                 userPrompt: 'If the last sentence is incomplete, only complete the sentence and nothing else. If the last sentence is complete, generate a new sentence that follows logically:\n---\n{{{pre_cursor}}}',
                 systemPrompt: "You are a writing assistant that predicts and completes sentences in a natural, context-aware manner. Your goal is to continue the user’s text smoothly, maintaining coherence, fluency, and style. Adapt to the user’s writing tone, whether formal, informal, creative, or technical. Ensure that completions feel intuitive, useful, and free of unnecessary repetition. Do not generate completion that includes the prompt itself.",
                 temperature: 0.5,
+                extraParams: {},
             }
         },
     },

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -12,7 +12,6 @@ export interface ProfileOptions {
     userPrompt: string,
     systemPrompt: string,
     temperature: number,
-    extraParams: Record<string, unknown>,
 }
 
 // Profile settings
@@ -111,6 +110,7 @@ export const DEFAULT_SETTINGS: Settings = {
             models: ["gpt-4o", "gpt-4o-mini"],
             configured: false,
             temperature_range: { min: 0, max: 1 },
+            extraParams: {},
         },
         gemini: {
             integration: ProviderType.GEMINI,
@@ -143,7 +143,6 @@ export const DEFAULT_SETTINGS: Settings = {
                 userPrompt: 'If the last sentence is incomplete, only complete the sentence and nothing else. If the last sentence is complete, generate a new sentence that follows logically:\n---\n{{{pre_cursor}}}',
                 systemPrompt: "You are a writing assistant that predicts and completes sentences in a natural, context-aware manner. Your goal is to continue the user’s text smoothly, maintaining coherence, fluency, and style. Adapt to the user’s writing tone, whether formal, informal, creative, or technical. Ensure that completions feel intuitive, useful, and free of unnecessary repetition. Do not generate completion that includes the prompt itself.",
                 temperature: 0.5,
-                extraParams: {},
             }
         },
     },

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -495,6 +495,29 @@ class ProfilesSection {
                     });
             });
 
+        // Extra Parameters
+        new Setting(this.container)
+            .setName("Extra parameters")
+            .setDesc(`${profile.name} | Only applicable to OpenAI-compatible providers. Additional parameters passed to the API (JSON format). Example: {"chat_template_kwargs": {"enable_thinking": false}}`)
+            .addTextArea((text) => {
+                text.inputEl.rows = 5;
+                text.setValue(JSON.stringify(profile.completionOptions.extraParams, null, 2))
+                    .setPlaceholder("{}")
+                    .onChange(async (value) => {
+                        try {
+                            const params = value.trim() ? JSON.parse(value) : {};
+                            if (typeof params === 'object' && params !== null && !Array.isArray(params)) {
+                                profile.completionOptions.extraParams = params;
+                                await this.plugin.saveSettings();
+                            } else {
+                                new Notice("Extra parameters must be a valid JSON object");
+                            }
+                        } catch (e) {
+                            new Notice("Invalid JSON format");
+                        }
+                    });
+            });
+
         // System Prompt
         new Setting(this.container)
             .setName("System prompt")

--- a/src/settings/tab.ts
+++ b/src/settings/tab.ts
@@ -495,29 +495,6 @@ class ProfilesSection {
                     });
             });
 
-        // Extra Parameters
-        new Setting(this.container)
-            .setName("Extra parameters")
-            .setDesc(`${profile.name} | Only applicable to OpenAI-compatible providers. Additional parameters passed to the API (JSON format). Example: {"chat_template_kwargs": {"enable_thinking": false}}`)
-            .addTextArea((text) => {
-                text.inputEl.rows = 5;
-                text.setValue(JSON.stringify(profile.completionOptions.extraParams, null, 2))
-                    .setPlaceholder("{}")
-                    .onChange(async (value) => {
-                        try {
-                            const params = value.trim() ? JSON.parse(value) : {};
-                            if (typeof params === 'object' && params !== null && !Array.isArray(params)) {
-                                profile.completionOptions.extraParams = params;
-                                await this.plugin.saveSettings();
-                            } else {
-                                new Notice("Extra parameters must be a valid JSON object");
-                            }
-                        } catch (e) {
-                            new Notice("Invalid JSON format");
-                        }
-                    });
-            });
-
         // System Prompt
         new Setting(this.container)
             .setName("System prompt")


### PR DESCRIPTION
Adds a UI section, allowing the user to add OpenAI-compatible provider specific extra parameters in JSON format.
I personally needed this to disable thinking on Qwen3.5, otherwise it takes ages for it to respond.