### PR TITLE
fix(openai-compat): use requestUrl() to bypass Electron CORS

### DIFF
--- a/src/providers/openai-compat/provider.ts
+++ b/src/providers/openai-compat/provider.ts
@@ -33,8 +33,10 @@ export class OpenAICompatibleProvider implements Provider {
                     { role: "user", content: prompt },
                 ],
                 temperature: options.temperature,
-                stream: false,
                 ...this.settings.extraParams,
+                // requestUrl() cannot consume SSE streams, so stream:false
+                // must win against any extraParams override.
+                stream: false,
             }),
             throw: false,
         });
@@ -85,11 +87,11 @@ export class OpenAICompatibleProvider implements Provider {
         if (!this.settings.baseUrl || !this.settings.apiKey) {
             return false;
         }
-        const model = this.settings.models[0];
-        if (!model) {
-            console.error("Inscribe: openai-compat connectionTest requires at least one configured model");
-            return false;
-        }
+        // connectionTest runs before fetchModels has populated the model
+        // list, so models[0] may be undefined. Fall back to a placeholder —
+        // a 4xx "model not found" still proves baseUrl + apiKey reach a
+        // working chat/completions endpoint.
+        const model = this.settings.models[0] ?? "inscribe-connection-test";
 
         try {
             const response = await requestUrl({
@@ -104,7 +106,14 @@ export class OpenAICompatibleProvider implements Provider {
                 }),
                 throw: false,
             });
-            if (response.status >= 200 && response.status < 300) {
+            // 401/403 = auth failure (real problem). 5xx = transient/unreachable.
+            // Anything else (200s, or a 400 "model not found") proves the
+            // endpoint is reachable and the credentials work.
+            if (response.status === 401 || response.status === 403) {
+                console.error("Inscribe: openai-compat connection test auth failure", response.status, response.text);
+                return false;
+            }
+            if (response.status >= 200 && response.status < 500) {
                 return true;
             }
             console.error("Inscribe: openai-compat connection test failed", response.status, response.text);

--- a/src/providers/openai-compat/provider.ts
+++ b/src/providers/openai-compat/provider.ts
@@ -1,80 +1,127 @@
 import { Provider } from "..";
-import { Editor } from "obsidian";
+import { Editor, requestUrl } from "obsidian";
 import { OpenAICompatibleSettings } from ".";
 import { ProfileOptions } from "src/settings/settings";
-import OpenAI from "openai";
 
+// Uses Obsidian's requestUrl() rather than the OpenAI SDK's fetch path so the
+// plugin can reach endpoints that don't enable browser CORS (notably
+// Anthropic's OpenAI-compatibility layer at https://api.anthropic.com/v1/).
+// Tradeoff: requestUrl() does not stream, so completions arrive as a single
+// buffered response. The Provider interface yields cumulative strings, so one
+// final yield is interface-compatible with the streaming providers.
 export class OpenAICompatibleProvider implements Provider {
-    client: OpenAI;
     settings: OpenAICompatibleSettings;
     aborted: boolean = false;
-    abortcontroller?: AbortController;
 
     constructor(settings: OpenAICompatibleSettings) {
         this.settings = settings;
-        this.client = new OpenAI({
-            baseURL: this.settings.baseUrl,
-            apiKey: this.settings.apiKey,
-            dangerouslyAllowBrowser: true,
-        });
     }
 
     async *generate(editor: Editor, prompt: string, options: ProfileOptions): AsyncGenerator<string> {
         this.aborted = false;
-        const abortcontroller = new AbortController();
-        this.abortcontroller = abortcontroller;
-
         const initialPosition = editor.getCursor();
-        const stream = await this.client.chat.completions.create({
-            model: options.model,
-            messages: [
-                { role: "system", content: options.systemPrompt },
-                { role: "user", content: prompt }
-            ],
-            temperature: options.temperature,
-            stream: true,
-            ...this.settings.extraParams,
-        }, { signal: abortcontroller.signal });
 
-        let completion = "";
-        for await (const chunk of stream) {
-            if (this.aborted) {
-                return;
-            }
-            if (this.cursorMoved(editor, initialPosition)) {
-                this.abort();
-                return;
-            }
+        const response = await requestUrl({
+            url: this.endpoint("chat/completions"),
+            method: "POST",
+            contentType: "application/json",
+            headers: this.authHeaders(),
+            body: JSON.stringify({
+                model: options.model,
+                messages: [
+                    { role: "system", content: options.systemPrompt },
+                    { role: "user", content: prompt },
+                ],
+                temperature: options.temperature,
+                stream: false,
+                ...this.settings.extraParams,
+            }),
+            throw: false,
+        });
 
-            const content = chunk.choices[0]?.delta?.content || "";
-            completion += content;
+        if (this.aborted || this.cursorMoved(editor, initialPosition)) {
+            return;
+        }
+
+        if (response.status < 200 || response.status >= 300) {
+            console.error("Inscribe: openai-compat request failed", response.status, response.text);
+            return;
+        }
+
+        const completion = response.json?.choices?.[0]?.message?.content ?? "";
+        if (completion) {
             yield completion;
         }
     }
 
     async abort() {
-        if (this.aborted) return;
+        // requestUrl() responses are buffered; the in-flight request cannot
+        // be cancelled. Flag the abort so any yield after the response
+        // returns is skipped.
         this.aborted = true;
-        this.abortcontroller?.abort();
     }
 
     async fetchModels(): Promise<string[]> {
-        if (!this.client) {
-            return this.settings.models;
+        try {
+            const response = await requestUrl({
+                url: this.endpoint("models"),
+                method: "GET",
+                headers: this.authHeaders(),
+                throw: false,
+            });
+            if (response.status >= 200 && response.status < 300 && Array.isArray(response.json?.data)) {
+                return response.json.data.map((m: { id: string }) => m.id);
+            }
+        } catch (error) {
+            console.error("Inscribe: openai-compat fetchModels failed", error);
         }
-
-        const models = await this.client.models.list();
-        return models.data.map(model => model.id);
+        // Many OpenAI-compatible endpoints (Anthropic, some self-hosted
+        // runtimes) don't implement /v1/models. Fall back to the user's
+        // configured list so the model picker isn't empty.
+        return this.settings.models;
     }
 
     async connectionTest(): Promise<boolean> {
-        try {
-            await this.client.models.list();
-            return true;
-        } catch (error) {
-            console.error("Error testing connection:", error);
+        if (!this.settings.baseUrl || !this.settings.apiKey) {
             return false;
         }
+        const model = this.settings.models[0];
+        if (!model) {
+            console.error("Inscribe: openai-compat connectionTest requires at least one configured model");
+            return false;
+        }
+
+        try {
+            const response = await requestUrl({
+                url: this.endpoint("chat/completions"),
+                method: "POST",
+                contentType: "application/json",
+                headers: this.authHeaders(),
+                body: JSON.stringify({
+                    model,
+                    messages: [{ role: "user", content: "ping" }],
+                    max_tokens: 1,
+                }),
+                throw: false,
+            });
+            if (response.status >= 200 && response.status < 300) {
+                return true;
+            }
+            console.error("Inscribe: openai-compat connection test failed", response.status, response.text);
+            return false;
+        } catch (error) {
+            console.error("Inscribe: openai-compat connection test error", error);
+            return false;
+        }
+    }
+
+    private endpoint(path: string): string {
+        const base = this.settings.baseUrl.endsWith("/") ? this.settings.baseUrl : `${this.settings.baseUrl}/`;
+        return base + (path.startsWith("/") ? path.slice(1) : path);
+    }
+
+    private authHeaders(): Record<string, string> {
+        return { "Authorization": `Bearer ${this.settings.apiKey}` };
     }
 
     private cursorMoved(editor: Editor, initialPosition: { line: number, ch: number }): boolean {
@@ -82,6 +129,3 @@ export class OpenAICompatibleProvider implements Provider {
         return currentPosition.line !== initialPosition.line || currentPosition.ch !== initialPosition.ch;
     }
 }
-
-// Import this at the end to avoid circular dependency issues
-import preparePrompt from "src/completions/prompt";


### PR DESCRIPTION
## Summary

The `openai_compatible` provider currently uses the OpenAI SDK, which makes requests via the renderer's `fetch()`. That path is blocked by Electron's CORS gate against any endpoint that doesn't echo a permissive `Access-Control-Allow-Origin` header — most notably **Anthropic's OpenAI compatibility layer at `https://api.anthropic.com/v1/`**, and a number of self-hosted runtimes.

Switching this single provider to Obsidian's `requestUrl()` (which runs in the main process and bypasses CORS) makes the provider work against those endpoints. The OpenAI and Ollama providers are untouched.

## Repro / evidence

Sending a CORS preflight to each provider from Obsidian's app origin shows the asymmetry clearly:

```
$ curl -sS -i -X OPTIONS https://api.anthropic.com/v1/chat/completions \
    -H 'Origin: app://obsidian.md' \
    -H 'Access-Control-Request-Method: POST' \
    -H 'Access-Control-Request-Headers: authorization,content-type'
HTTP/2 400
...
Disallowed CORS origin

$ curl -sS -i -X OPTIONS https://api.openai.com/v1/chat/completions \
    -H 'Origin: app://obsidian.md' \
    -H 'Access-Control-Request-Method: POST' \
    -H 'Access-Control-Request-Headers: authorization,content-type'
HTTP/2 200
access-control-allow-origin: app://obsidian.md
```

In the renderer this surfaces as:

```
Access to fetch at 'https://api.anthropic.com/v1/chat/completions' from origin
'app://obsidian.md' has been blocked by CORS policy: Response to preflight
request doesn't pass access control check: No 'Access-Control-Allow-Origin'
header is present on the requested resource.
TypeError: Failed to fetch
    at ve.fetchWithTimeout (plugin:inscribe:92:5521)
```

The chat/completions call itself works fine when made server-side (curl with `Authorization: Bearer <key>` against `https://api.anthropic.com/v1/chat/completions` returns a valid OpenAI-shaped response with a Claude model name). It's only the renderer's CORS check that blocks it.

This is the same class-of-bug other Obsidian AI plugins have hit when adding Anthropic support: [Smart Connections #1000](https://github.com/brianpetro/obsidian-smart-connections/issues/1000), [Smart Connections #1006](https://github.com/brianpetro/obsidian-smart-connections/issues/1006), [Text Generator #259](https://github.com/nhaouari/obsidian-textgenerator-plugin/issues/259), [Smart Composer #485](https://github.com/glowingjade/obsidian-smart-composer/issues/485). Anthropic's stance on enabling browser CORS is \"not planned\" ([anthropic-sdk-typescript#342](https://github.com/anthropics/anthropic-sdk-typescript/issues/342)) — so `requestUrl()` is the structural workaround the Obsidian ecosystem has converged on.

## Changes

`src/providers/openai-compat/provider.ts` only:

- **`generate()`** — replace the `OpenAI` client + `chat.completions.create({ stream: true })` with a single `requestUrl({ method: 'POST', body: { …, stream: false } })`. Yield the full completion as one chunk. The `Provider` interface yields cumulative strings, so this stays interface-compatible with the streaming providers and no caller needs to change.
- **`connectionTest()`** — was `client.models.list()`, which fails against Anthropic and many self-hosted backends that don't implement `/v1/models`. Now sends a tiny `chat.completions` ping with `max_tokens: 1` against the first configured model. This is the endpoint we actually depend on, so it's a more accurate probe.
- **`fetchModels()`** — falls back to the user's configured `models` list when `/v1/models` returns a non-2xx. Previously this threw and left the model picker stuck.

## Tradeoffs

- **Streaming is dropped for this provider.** `requestUrl()` does not stream response bodies as of [the open feature request](https://forum.obsidian.md/t/support-streaming-the-request-and-requesturl-response-body/87381). For inline autocompletion of short snippets the perceived latency change is small (~one round-trip's worth, instead of progressive ghost-text appearance). For users running long-form completions against fast endpoints this is a UX regression. If you'd prefer to keep streaming as an option, I'm happy to follow up with a per-provider \"bypass CORS (no streaming)\" toggle.
- **`abort()` can no longer cancel an in-flight request.** It sets a flag and the post-response yield is skipped. Tokens are still spent if the user moves the cursor after the request is in flight. Same root cause: `requestUrl()` doesn't expose cancellation.
- **Behavior for current OpenAI/Together/Groq users.** OpenAI works either way; Together and Groq both send permissive CORS so they worked under the SDK path too. After this change they'll still work, but lose streaming. The other affected providers gain compatibility.

The `OpenAI` and `Ollama` providers are untouched — `api.openai.com` sends CORS-allow-origin for any browser origin, and Ollama is localhost.

## Test plan

- [x] `npm run build` clean (tsc + esbuild, no errors)
- [x] Loaded built `main.js` into a real vault with `baseUrl=https://api.anthropic.com/v1/`, Anthropic API key, `model=claude-haiku-4-5` — inline completions work, no CORS errors in console
- [x] Existing data.json shape preserved (no settings migration needed)
- [ ] Maintainer to verify: OpenAI provider users still unaffected (no code change there)